### PR TITLE
Add mutation testing (Closes #13)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,32 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktor) apply false
+    alias(libs.plugins.pitest) apply false
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+    }
 }
 
 subprojects {
     group = "com.xkcddatahub"
     version = "0.0.1"
 
-    repositories {
-        mavenCentral()
+    apply(plugin = "info.solidsoft.pitest")
+
+    afterEvaluate {
+        plugins.withId("info.solidsoft.pitest") {
+            configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
+                targetClasses.set(listOf("com.xkcddatahub.*"))
+                threads.set(Runtime.getRuntime().availableProcessors())
+                outputFormats.set(listOf("XML", "HTML"))
+                timestampedReports.set(false)
+                excludedClasses = listOf(
+                    "com.xkcddatahub.*.di.*"
+                )
+            }
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlin = "2.0.0"
 ktor = "2.3.11"
 logback = "1.5.6"
 mockk = "1.13.11"
+pitest = "1.15.0"
 postgres = "42.7.3"
 
 [libraries]
@@ -46,6 +47,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin_serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
+pitest = { id = "info.solidsoft.pitest", version.ref = "pitest" }
 
 [bundles]
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,4 @@
 rootProject.name = "xkcd-data-hub"
 include(
-    "fetcher",
-    "writer"
+    "fetcher"
 )


### PR DESCRIPTION
# Purpose

This commit adds PIT as the mutation test framework for all subprojects within this repository.

Later on, the report will be calculated once a week by a GitHub cronjob and updated in the UI. However, for now, the report can be called only manually as the calculation time of it takes some time.