### PR TITLE
Remove `pull_request_target`

### DIFF
--- a/.github/workflows/continues-integration.yml
+++ b/.github/workflows/continues-integration.yml
@@ -3,8 +3,6 @@ name: Continuous Integration
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-  pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 coroutines = "1.8.1"
-exposed = "0.51.1"
+exposed = "0.51.0"
 koin = "3.5.6"
 kotest = "4.0.7"
 kotlin = "2.0.0"


### PR DESCRIPTION

# Purpose

This commit removes `pull_request_target` as it caused CI to run twice on every PR opened
