### PR TITLE
Repeat fetch very 24h

### DIFF
--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/Application.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/Application.kt
@@ -5,9 +5,11 @@ import com.xkcddatahub.fetcher.bootstrap.di.allModules
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.ktor.ext.inject
 import org.koin.ktor.plugin.Koin
+import kotlin.time.Duration.Companion.hours
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
@@ -20,8 +22,14 @@ fun Application.module() {
 
     DatabaseFactory(environment.config).init()
 
+    fetchXkcdComics()
+}
+
+private fun Application.fetchXkcdComics() =
     launch(Dispatchers.IO) {
         val getAllXkcdComics by inject<GetAllXkcdComics>()
-        getAllXkcdComics()
+        while (true) {
+            getAllXkcdComics()
+            delay(24.hours.inWholeMilliseconds)
+        }
     }
-}

--- a/fetcher/src/main/resources/application.conf
+++ b/fetcher/src/main/resources/application.conf
@@ -3,7 +3,7 @@ ktor {
     modules = [ "com.xkcddatahub.fetcher.bootstrap.ApplicationKt.module" ]
   }
   deployment {
-    port = 8080
+    port = 8090
   }
   database {
     url = "jdbc:postgresql://localhost:5432/xkcd_data_hub"


### PR DESCRIPTION


# Purpose

This commit wraps the fetch functionality in a suspend operation that repeats every 24h, so if new comics are added while the service is running, it will be fetched on the next day.