### PR TITLE
Move Entities to Domain package

### DIFF
--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
@@ -4,7 +4,7 @@ import com.xkcddatahub.fetcher.adapters.output.database.postgres.mappers.Databas
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComicsTable
 import com.xkcddatahub.fetcher.application.ports.WebComicsPort
 import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.dbQuery
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.max
 

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/mappers/DatabaseWebComicsMapper.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/mappers/DatabaseWebComicsMapper.kt
@@ -1,7 +1,7 @@
 package com.xkcddatahub.fetcher.adapters.output.database.postgres.mappers
 
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.data.DatabaseWebComics
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 
 object DatabaseWebComicsMapper {
     fun WebComics.toData() =

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapper.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapper.kt
@@ -1,7 +1,7 @@
 package com.xkcddatahub.fetcher.adapters.output.http.rest.xkcd.mappers
 
 import com.xkcddatahub.fetcher.adapters.output.http.rest.xkcd.data.ApiWebComics
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 
 object ApiWebComicsMapper {
     fun ApiWebComics.toDomain() =

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/application/ports/WebComicsPort.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/application/ports/WebComicsPort.kt
@@ -1,6 +1,6 @@
 package com.xkcddatahub.fetcher.application.ports
 
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 
 interface WebComicsPort {
     suspend fun save(comics: WebComics): Boolean

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/application/ports/XkcdClientPort.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/application/ports/XkcdClientPort.kt
@@ -1,6 +1,6 @@
 package com.xkcddatahub.fetcher.application.ports
 
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 
 interface XkcdClientPort {
     suspend fun getLatestComicId(): Int

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/domain/entity/WebComics.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/domain/entity/WebComics.kt
@@ -1,4 +1,4 @@
-package com.xkcddatahub.fetcher.entity
+package com.xkcddatahub.fetcher.domain.entity
 
 data class WebComics(
     val id: Int,

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/database/postgres/mappers/DatabaseWebComicsMapperTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/database/postgres/mappers/DatabaseWebComicsMapperTest.kt
@@ -2,7 +2,7 @@ package com.xkcddatahub.fetcher.output.database.postgres.mappers
 
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.data.DatabaseWebComics
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.mappers.DatabaseWebComicsMapper.toData
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/http/rest/xkcd/mappers/ApiWebComicsMapperTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/http/rest/xkcd/mappers/ApiWebComicsMapperTest.kt
@@ -2,7 +2,7 @@ package com.xkcddatahub.fetcher.output.http.rest.xkcd.mappers
 
 import com.xkcddatahub.fetcher.adapters.output.http.rest.xkcd.data.ApiWebComics
 import com.xkcddatahub.fetcher.adapters.output.http.rest.xkcd.mappers.ApiWebComicsMapper.toDomain
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/usercases/GetAllXkcdComicsTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/usercases/GetAllXkcdComicsTest.kt
@@ -3,7 +3,7 @@ package com.xkcddatahub.fetcher.usercases
 import com.xkcddatahub.fetcher.application.ports.WebComicsPort
 import com.xkcddatahub.fetcher.application.ports.XkcdClientPort
 import com.xkcddatahub.fetcher.application.usecases.GetAllXkcdComics
-import com.xkcddatahub.fetcher.entity.WebComics
+import com.xkcddatahub.fetcher.domain.entity.WebComics
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify


### PR DESCRIPTION

# Purpose

This commit moves the `entities` package to be under the `domain` module as it was missing from the architecture.
