### PR TITLE
Enable environment variables configuration (Closes #52)

### DIFF
--- a/fetcher/src/main/resources/application.conf
+++ b/fetcher/src/main/resources/application.conf
@@ -4,11 +4,15 @@ ktor {
   }
   deployment {
     port = 8090
+    port = ${?PORT}
   }
   database {
     url = "jdbc:postgresql://localhost:5432/xkcd_data_hub"
+    url = ${?JDBC_DATABASE_URL}
     driver = "org.postgresql.Driver"
     user = "postgres"
+    user = ${?DATABASE_USERNAME}
     password = "secret"
+    password = ${?DATABASE_PASSWORD}
   }
 }


### PR DESCRIPTION

# Purpose

This commit enables to configure the service port, and the database url, username and password via environment variables during the deployment of the service instead of the previously hard-coded values
