### PR TITLE
Add integration tests to fetcher (Closes #12)

### DIFF
--- a/fetcher/build.gradle.kts
+++ b/fetcher/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     implementation(libs.bundles.persistance.all)
     implementation(libs.logback)
     testImplementation(libs.bundles.tests.all)
+    testImplementation(libs.bundles.persistance.test.all)
 }

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
@@ -5,14 +5,14 @@ import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComics
 import com.xkcddatahub.fetcher.application.ports.WebComicsPort
 import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.dbQuery
 import com.xkcddatahub.fetcher.domain.entity.WebComics
-import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.max
 
 class WebComicPostgresAdapter : WebComicsPort {
     override suspend fun save(comics: WebComics): Boolean =
         dbQuery {
             val data = comics.toData()
-            WebComicsTable.insert {
+            WebComicsTable.insertIgnore {
                 it[id] = data.id
                 it[year] = data.year
                 it[month] = data.month

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/Application.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/Application.kt
@@ -20,7 +20,7 @@ fun Application.module() {
         modules(allModules)
     }
 
-    DatabaseFactory(environment.config).init()
+    DatabaseFactory.from(environment.config).init()
 
     fetchXkcdComics()
 }

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/DatabaseFactory.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/DatabaseFactory.kt
@@ -8,12 +8,12 @@ import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 
-class DatabaseFactory(config: ApplicationConfig) {
-    private val url = config.property("ktor.database.url").getString()
-    private val driver = config.property("ktor.database.driver").getString()
-    private val username = config.property("ktor.database.user").getString()
-    private val password = config.property("ktor.database.password").getString()
-
+class DatabaseFactory(
+    private val url: String,
+    private val driver: String,
+    private val username: String,
+    private val password: String,
+) {
     fun init() {
         val connection = hikari()
         Database.connect(connection)
@@ -40,6 +40,14 @@ class DatabaseFactory(config: ApplicationConfig) {
     }
 
     companion object {
+        fun from(config: ApplicationConfig): DatabaseFactory =
+            DatabaseFactory(
+                url = config.property("ktor.database.url").getString(),
+                driver = config.property("ktor.database.driver").getString(),
+                username = config.property("ktor.database.user").getString(),
+                password = config.property("ktor.database.password").getString(),
+            )
+
         suspend fun <T> dbQuery(block: suspend () -> T): T =
             newSuspendedTransaction(
                 Dispatchers.IO,

--- a/fetcher/src/main/resources/application.conf
+++ b/fetcher/src/main/resources/application.conf
@@ -8,7 +8,7 @@ ktor {
   }
   database {
     url = "jdbc:postgresql://localhost:5432/xkcd_data_hub"
-    url = ${?JDBC_DATABASE_URL}
+    url = ${?DATABASE_URL}
     driver = "org.postgresql.Driver"
     user = "postgres"
     user = ${?DATABASE_USERNAME}

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/AbstractIntegrationTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/AbstractIntegrationTest.kt
@@ -1,0 +1,38 @@
+package com.xkcddatahub.fetcher.output
+
+import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+
+abstract class AbstractIntegrationTest {
+    companion object {
+        @Container
+        val postgresContainer: PostgreSQLContainer<*> =
+            PostgreSQLContainer<Nothing>("postgres:16")
+                .apply {
+                    withDatabaseName("xkcd_data_hub")
+                    withUsername("test")
+                    withPassword("test")
+                }
+                .also { if (!it.isRunning) it.start() }
+
+        @JvmStatic
+        @BeforeAll
+        fun initialize() {
+            DatabaseFactory(
+                url = postgresContainer.jdbcUrl,
+                driver = "org.postgresql.Driver",
+                username = postgresContainer.username,
+                password = postgresContainer.password,
+            ).init()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun finalized() {
+            postgresContainer.stop()
+        }
+    }
+}

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/database/postgres/WebComicsPostgresAdapterTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/output/database/postgres/WebComicsPostgresAdapterTest.kt
@@ -1,5 +1,194 @@
 package com.xkcddatahub.fetcher.output.database.postgres
 
-class WebComicsPostgresAdapterTest {
-    // TODO: create test with test containers
+import com.xkcddatahub.fetcher.adapters.output.database.postgres.WebComicPostgresAdapter
+import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComicsTable
+import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.dbQuery
+import com.xkcddatahub.fetcher.domain.entity.WebComics
+import com.xkcddatahub.fetcher.output.AbstractIntegrationTest
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.selectAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
+    @BeforeEach
+    fun setup() =
+        runTest {
+            dbQuery {
+                SchemaUtils.create(WebComicsTable)
+            }
+        }
+
+    @AfterEach
+    fun tearDown() =
+        runTest {
+            dbQuery {
+                SchemaUtils.drop(WebComicsTable)
+            }
+        }
+
+    @Test
+    fun `test save web comic`() =
+        runTest {
+            // Given
+            val webComic = buildWebComics()
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            val result = webComicPostgresAdapter.save(webComic)
+
+            // Then
+            result shouldBe true
+
+            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            storedComics.size shouldBe 1
+
+            val storedComic = storedComics.first()
+            assertWebComicsAreEqual(webComic, storedComic)
+        }
+
+    @Test
+    fun `test save duplicate web comic`() =
+        runTest {
+            // Given
+            val webComic = buildWebComics(1)
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+            webComicPostgresAdapter.save(webComic)
+
+            // When
+            val result = webComicPostgresAdapter.save(webComic)
+
+            // Then
+            result shouldBe false
+
+            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            storedComics.size shouldBe 1
+        }
+
+    @Test
+    fun `test save web comic with null link and news`() =
+        runTest {
+            // Given
+            val webComic = buildWebComics(id = 1, news = null, link = null)
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            val result = webComicPostgresAdapter.save(webComic)
+
+            // Then
+            result shouldBe true
+
+            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            storedComics.size shouldBe 1
+
+            val storedComic = storedComics.first()
+            assertWebComicsAreEqual(webComic, storedComic)
+        }
+
+    @Test
+    fun `test concurrency save operations`() =
+        runTest {
+            // Given
+            val webComics = (1..100).map { buildWebComics(it) }
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            val results =
+                webComics.map { comic ->
+                    async { webComicPostgresAdapter.save(comic) }
+                }.awaitAll()
+
+            // Then
+            results.forEach { it shouldBe true }
+            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            storedComics.size shouldBe 100
+        }
+
+    @Test
+    fun `test get latest stored comic id`() =
+        runTest {
+            // Given
+            val webComic1 = buildWebComics(1)
+            val webComic2 = buildWebComics(2)
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            webComicPostgresAdapter.save(webComic1)
+            webComicPostgresAdapter.save(webComic2)
+
+            // Then
+            val latestStoredComicId = webComicPostgresAdapter.getLatestStoredComicId()
+            latestStoredComicId shouldBe 2
+        }
+
+    @Test
+    fun `test get latest comic id with no comics`() =
+        runTest {
+            // Given
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            val latestStoredComicId = webComicPostgresAdapter.getLatestStoredComicId()
+
+            // Then
+            latestStoredComicId shouldBe 0
+        }
+
+    @Test
+    fun `test boundary condition for comic ids`() =
+        runTest {
+            // Given
+            val webComic = buildWebComics(Int.MAX_VALUE)
+            val webComicPostgresAdapter = WebComicPostgresAdapter()
+
+            // When
+            val result = webComicPostgresAdapter.save(webComic)
+
+            // Then
+            result shouldBe true
+
+            val latestStoredComicId = webComicPostgresAdapter.getLatestStoredComicId()
+            latestStoredComicId shouldBe Int.MAX_VALUE
+        }
+
+    private fun buildWebComics(
+        id: Int = 1,
+        news: String? = "Test news",
+        link: String? = "http://testurl.com",
+    ) = WebComics(
+        id = id,
+        year = 2024,
+        month = 6,
+        day = 24,
+        title = "Test Comic",
+        safeTitle = "Test Comic Safe",
+        transcript = "This is a test transcript",
+        alternativeText = "Test alternative text",
+        imageUrl = "http://testurl.com/comic.png",
+        news = news,
+        link = link,
+    )
+
+    private fun assertWebComicsAreEqual(
+        expected: WebComics,
+        actual: ResultRow,
+    ) {
+        actual[WebComicsTable.id] shouldBe expected.id
+        actual[WebComicsTable.year] shouldBe expected.year
+        actual[WebComicsTable.month] shouldBe expected.month
+        actual[WebComicsTable.day] shouldBe expected.day
+        actual[WebComicsTable.title] shouldBe expected.title
+        actual[WebComicsTable.safeTitle] shouldBe expected.safeTitle
+        actual[WebComicsTable.transcript] shouldBe expected.transcript
+        actual[WebComicsTable.alternativeText] shouldBe expected.alternativeText
+        actual[WebComicsTable.imageUrl] shouldBe expected.imageUrl
+        actual[WebComicsTable.news] shouldBe expected.news
+        actual[WebComicsTable.link] shouldBe expected.link
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ mockk = "1.13.11"
 pitest = "1.15.0"
 postgres = "42.7.3"
 spotless = "6.25.0"
+testContainers = "1.19.8"
 
 [libraries]
 
@@ -46,6 +47,8 @@ kotlin_test_junit = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versio
 ktor_client_mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor_tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+test_containers = { module = "org.testcontainers:junit-jupiter", version.ref = "testContainers" }
+test_containers_postgres = { module = "org.testcontainers:postgresql", version.ref = "testContainers" }
 
 [plugins]
 kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -72,6 +75,11 @@ persistance_all = [
     "flyway",
     "hikari",
     "postgres_driver",
+]
+
+persistance_test_all = [
+    "test_containers",
+    "test_containers_postgres",
 ]
 
 tests_all = [


### PR DESCRIPTION

# Purpose

This commit adds missing integration tests to the fetcher project that leverages TestContainers and ensures the functionality of the database integration.

There is still a need to write e2e test for the entire application, but as the application does not have any REST endpoint I need to do more reading and check how to test the context loading.