### PR TITLE
Rename dbQuery to transaction

### DIFF
--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
@@ -3,14 +3,14 @@ package com.xkcddatahub.fetcher.adapters.output.database.postgres
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.mappers.DatabaseWebComicsMapper.toData
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComicsTable
 import com.xkcddatahub.fetcher.application.ports.WebComicsPort
-import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.dbQuery
+import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.transaction
 import com.xkcddatahub.fetcher.domain.entity.WebComics
 import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.max
 
 class WebComicPostgresAdapter : WebComicsPort {
     override suspend fun save(comics: WebComics): Boolean =
-        dbQuery {
+        transaction {
             val data = comics.toData()
             WebComicsTable.insertIgnore {
                 it[id] = data.id
@@ -28,7 +28,7 @@ class WebComicPostgresAdapter : WebComicsPort {
         }
 
     override suspend fun getLatestStoredComicId(): Int =
-        dbQuery {
+        transaction {
             WebComicsTable
                 .select(WebComicsTable.id.max())
                 .single()[WebComicsTable.id.max()]

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/DatabaseFactory.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/bootstrap/DatabaseFactory.kt
@@ -48,7 +48,7 @@ class DatabaseFactory(
                 password = config.property("ktor.database.password").getString(),
             )
 
-        suspend fun <T> dbQuery(block: suspend () -> T): T =
+        suspend fun <T> transaction(block: suspend () -> T): T =
             newSuspendedTransaction(
                 Dispatchers.IO,
             ) { block() }

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicsPostgresAdapterTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicsPostgresAdapterTest.kt
@@ -2,7 +2,7 @@ package com.xkcddatahub.fetcher.adapters.output.database.postgres
 
 import com.xkcddatahub.fetcher.adapters.output.AbstractIntegrationTest
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComicsTable
-import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.dbQuery
+import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.transaction
 import com.xkcddatahub.fetcher.domain.entity.WebComics
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.async
@@ -19,7 +19,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
     @BeforeEach
     fun setup() =
         runTest {
-            dbQuery {
+            transaction {
                 SchemaUtils.create(WebComicsTable)
             }
         }
@@ -27,7 +27,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
     @AfterEach
     fun tearDown() =
         runTest {
-            dbQuery {
+            transaction {
                 SchemaUtils.drop(WebComicsTable)
             }
         }
@@ -45,7 +45,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
             // Then
             result shouldBe true
 
-            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            val storedComics = transaction { WebComicsTable.selectAll().toList() }
             storedComics.size shouldBe 1
 
             val storedComic = storedComics.first()
@@ -66,7 +66,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
             // Then
             result shouldBe false
 
-            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            val storedComics = transaction { WebComicsTable.selectAll().toList() }
             storedComics.size shouldBe 1
         }
 
@@ -83,7 +83,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
             // Then
             result shouldBe true
 
-            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            val storedComics = transaction { WebComicsTable.selectAll().toList() }
             storedComics.size shouldBe 1
 
             val storedComic = storedComics.first()
@@ -105,7 +105,7 @@ class WebComicsPostgresAdapterTest : AbstractIntegrationTest() {
 
             // Then
             results.forEach { it shouldBe true }
-            val storedComics = dbQuery { WebComicsTable.selectAll().toList() }
+            val storedComics = transaction { WebComicsTable.selectAll().toList() }
             storedComics.size shouldBe 100
         }
 


### PR DESCRIPTION


# Purpose

This commit only changes the name of the extension function used to manage Exposed from `dbQuery` to `transaction` to better reflect on its purpose