### PR TITLE
Refactor version catalog

### DIFF
--- a/fetcher/build.gradle.kts
+++ b/fetcher/build.gradle.kts
@@ -14,9 +14,11 @@ application {
 dependencies {
     implementation(libs.bundles.ktor.all)
     implementation(libs.koin)
+    implementation(libs.bundles.exposed.all)
     implementation(libs.bundles.persistance.all)
     implementation(libs.logback)
     testImplementation(libs.koin.test)
     testImplementation(libs.bundles.tests.all)
+    testImplementation(libs.bundles.ktor.test.all)
     testImplementation(libs.bundles.persistance.test.all)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ ktor_client_content_negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor_core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor_serialization_kotlinx_json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor_server_netty_jvm = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor_client_mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor_tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
 
 ## DI
 koin = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
@@ -45,9 +47,9 @@ logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kotest_assertions_jvm = { module = "io.kotest:kotest-assertions-jvm", version.ref = "kotest" }
 kotlin_coroutines_test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin_test_junit = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
-ktor_client_mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
-ktor_tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+## Test Containers
 test_containers = { module = "org.testcontainers:junit-jupiter", version.ref = "testContainers" }
 test_containers_postgres = { module = "org.testcontainers:postgresql", version.ref = "testContainers" }
 
@@ -68,11 +70,19 @@ ktor_all = [
     "ktor_server_netty_jvm",
 ]
 
-persistance_all = [
+ktor_test_all = [
+    "ktor_client_mock",
+    "ktor_tests",
+]
+
+exposed_all = [
     "exposed_core",
     "exposed_dao",
     "exposed_java_time",
     "exposed_jdbc",
+]
+
+persistance_all = [
     "flyway",
     "hikari",
     "postgres_driver",
@@ -87,7 +97,5 @@ tests_all = [
     "kotest_assertions_jvm",
     "kotlin_coroutines_test",
     "kotlin_test_junit",
-    "ktor_client_mock",
-    "ktor_tests",
     "mockk"
 ]


### PR DESCRIPTION

# Purpose

This commit refactors the version catalog to enable more granular control over which versions are included or excluded from each of the modules in the project.

This allows, for example, reusing bundles like `test-all` without the need to exclude ktor-specific dependencies in a non-ktor submodule
