### PR TITLE
Define XKCD Data-Hub API (Closes #38)

### DIFF
--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
@@ -23,3 +25,103 @@ tasks {
         enabled = true
     }
 }
+
+/*
+ ********************************************
+ ********* OPEN API SPEC GENERATION *********
+ ********************************************
+*/
+
+val apiDirectoryPath = "$projectDir/src/main/resources/api"
+val openApiGenerateOutputDir = "${layout.buildDirectory.get()}/generated/openapi"
+
+data class ApiSpec(
+    val name: String,
+    val taskName: String,
+    val directoryPath: String,
+    val outputDir: String,
+    val specFileName: String,
+    val generatorType: String,
+    val packageName: String,
+    val modelPackageName: String,
+    val config: Map<String, String> = emptyMap(),
+    val templatesDir: String? = null,
+)
+
+/**
+ * List of all api specs to generate
+ */
+val supportedApis =
+    listOf(
+        ApiSpec(
+            name = "Gateway API",
+            taskName = "generateGatewayApi",
+            directoryPath = apiDirectoryPath,
+            outputDir = "$openApiGenerateOutputDir/gateway",
+            specFileName = "xkcd-data-hub-api.yaml",
+            generatorType = "kotlin-spring",
+            packageName = "com.xkcddatahub.gateway.openapi.v1",
+            modelPackageName = "com.xkcddatahub.gateway.openapi.v1.models",
+            config =
+                mapOf(
+                    "dateLibrary" to "java8",
+                    "enumPropertyNaming" to "UPPERCASE",
+                    "interfaceOnly" to "true",
+                    "implicitHeaders" to "true",
+                    "hideGenerationTimestamp" to "true",
+                    "useTags" to "true",
+                    "documentationProvider" to "none",
+                    "useSpringBoot3" to "true",
+                    "reactive" to "true",
+                ),
+        ),
+    )
+
+// Iterate over the api list and register them as generator tasks
+supportedApis.forEach { api ->
+    tasks.register<GenerateTask>(api.taskName) {
+        group = "openapi tools"
+        description = "Generate the code for ${api.name}"
+
+        generatorName.set(api.generatorType)
+        inputSpec.set("${api.directoryPath}/${api.specFileName}")
+        outputDir.set(api.outputDir)
+        apiPackage.set(api.packageName)
+        modelPackage.set(api.modelPackageName)
+        configOptions.set(api.config)
+        api.templatesDir?.let { templateDir.set(it) }
+    }
+}
+
+tasks {
+    register("cleanGeneratedCodeTask") {
+        description = "Removes generated Open API code"
+        group = "openapi tools"
+
+        doLast {
+            logger.info("Cleaning up generated code")
+            File(openApiGenerateOutputDir).deleteRecursively()
+        }
+    }
+
+    clean {
+        dependsOn("cleanGeneratedCodeTask")
+        supportedApis.forEach { finalizedBy(it.taskName) }
+    }
+
+    compileKotlin {
+        supportedApis.forEach { dependsOn(it.taskName) }
+    }
+}
+
+supportedApis.forEach {
+    sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].java {
+        srcDir("${it.outputDir}/src/main/kotlin")
+    }
+}
+
+/*
+ ********************************************
+ ******* OPEN API SPEC GENERATION END *******
+ ********************************************
+*/

--- a/gateway/src/main/resources/api/xkcd-data-hub-api.yaml
+++ b/gateway/src/main/resources/api/xkcd-data-hub-api.yaml
@@ -1,0 +1,229 @@
+openapi: 3.0.3
+info:
+  title: XKCD Data Hub API
+  description: |
+    The XKCD Data Hub API provides an entry point for fetching and streaming
+    XKCD comic data. Users can retrieve information about specific comics,
+    search by keywords, or get the latest comics.
+  contact:
+    name: Yonatan Karp-Rudin
+    url: http://yonatankarp.com
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development environment
+
+tags:
+  - name: GetByComicId
+    description: Retrieve XKCD comic by ID
+  - name: Search
+    description: Search XKCD comics
+  - name: GetLatestComics
+    description: Retrieve the latest XKCD comic
+  - name: XkcdDataHubV1
+    description: Endpoints for XKCD Data Hub version 1
+
+paths:
+  /xkcd/webcomics/{comicId}:
+    get:
+      operationId: getXkcdComicById
+      summary: Retrieve XKCD comic by ID
+      description: |
+        This endpoint retrieves the XKCD comic associated with the specified ID.
+      tags:
+        - GetByComicId
+        - XkcdDataHubV1
+      parameters:
+        - name: comicId
+          in: path
+          required: true
+          description: The ID of the XKCD comic to retrieve
+          schema:
+            type: integer
+            example: 123
+      responses:
+        "200":
+          description: A successful response containing information about the XKCD comic.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComicResponse"
+        "400":
+          description: The request was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: The requested resource was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: An unexpected server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+
+  /xkcd/webcomics/search:
+    get:
+      operationId: search_as_you_type
+      summary: Search XKCD comics by keyword
+      description: |
+        This endpoint searches XKCD comics based on the provided keyword.
+      tags:
+        - Search
+        - XkcdDataHubV1
+      parameters:
+        - name: keyword
+          in: query
+          required: true
+          description: The keyword to search for in XKCD comics
+          schema:
+            type: string
+            example: "science"
+      responses:
+        "200":
+          description: A successful response containing a list of XKCD comics matching the keyword.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ComicResponse"
+        "400":
+          description: The request was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: An unexpected server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+
+  /xkcd/webcomics/latest:
+    get:
+      operationId: get_latest_xkcd_comics
+      summary: Retrieve the latest XKCD comics
+      description: |
+        This endpoint retrieves the latest XKCD comic.
+      tags:
+        - GetLatestComics
+        - XkcdDataHubV1
+      responses:
+        "200":
+          description: A successful response containing information about the latest XKCD comic.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComicResponse"
+        "500":
+          description: An unexpected server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+
+components:
+  schemas:
+    ComicResponse:
+      type: object
+      required:
+        - id
+        - year
+        - month
+        - day
+        - title
+        - safe_title
+        - alternative_text
+        - image_url
+        - created_at
+      properties:
+        id:
+          type: integer
+          description: The ID of the XKCD comic
+          example: 426
+        year:
+          type: integer
+          description: The year the XKCD comic was published
+          example: 2008
+        month:
+          type: integer
+          description: The month the XKCD comic was published
+          example: 5
+        day:
+          type: integer
+          description: The day the XKCD comic was published
+          example: 21
+        title:
+          type: string
+          description: The title of the XKCD comic
+          example: "Geohashing"
+        safe_title:
+          type: string
+          description: The safe title of the XKCD comic
+          example: "Geohashing"
+        transcript:
+          type: string
+          description: The transcript of the XKCD comic
+          example: |
+            Date (example): 2005-05-26
+            That date's (or most recent) DOW opening: 10458.68
+            [[Concatenate, with a hyphen: 2005-05-26-10458.68]]
+            md5: db9318c2259923d08b672cb305440f97
+            [[Split it up into two pieces:]]
+            0.db9318c2259923d0, 0.8b672cb305440f97
+            To decimal: 0.857713..., 0.544544...
+            Your location (example): 37.421542, -122.085589
+            [[Combine integer part of location with fractional part of hash:]]
+            Destination Coordinates: 37.857713, -122.544544
+            Sample Implementation: http:
+            xkcd.com
+            geohashing
+            {{title text: Saturday is game night.}}
+        alternative_text:
+          type: string
+          description: The alternative text of the XKCD comic
+          example: "Saturday is game night."
+        image_url:
+          type: string
+          description: The URL of the XKCD comic image
+          example: "https://imgs.xkcd.com/comics/geohashing.png"
+        news:
+          type: string
+          description: News related to the XKCD comic
+          example: What is this about?  See the <a href="https://wiki.xkcd.com/geohashing/">wiki</a>.
+        link:
+          type: string
+          description: Additional link related to the XKCD comic
+          example: "https://xkcd.com/geohashing"
+        created_at:
+          type: string
+          description: The creation date of the XKCD comic
+          format: date-time
+          example: "2024-06-30T14:48:00.000Z"
+
+    ApiError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: "NotFound"
+        message:
+          type: string
+          description: A human-readable error message
+          example: "The requested resource was not found"
+        details:
+          type: string
+          description: Additional details about the error
+          example: "No comic found with ID 123"


### PR DESCRIPTION
# Purpose

This commit defines the spec between the gateway service and the clients, and the endpoints that are being exposed to them.

The API defines the following functionality that can be used by the clients:

- Fetch comics by specific id
- Fetch the latest comics
- SAYT functionality (fuzzy matching)