### PR TITLE
[Bugfix] news and link are not stored as `null` when missing

### DIFF
--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapper.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapper.kt
@@ -15,7 +15,7 @@ object ApiWebComicsMapper {
             transcript = transcript,
             alternativeText = alternativeText,
             imageUrl = imageUrl,
-            news = news,
-            link = link,
+            news = news?.takeIf { it.isNotBlank() },
+            link = link?.takeIf { it.isNotBlank() },
         )
 }

--- a/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapperTest.kt
+++ b/fetcher/src/test/kotlin/com/xkcddatahub/fetcher/adapters/output/http/rest/xkcd/mappers/ApiWebComicsMapperTest.kt
@@ -34,8 +34,8 @@ class ApiWebComicsMapperTest {
     }
 
     private fun apiWebComics(
-        news: String? = null,
-        link: String? = null,
+        news: String = "",
+        link: String = "",
     ) = ApiWebComics(
         id = 2,
         year = "2022",


### PR DESCRIPTION

# Purpose

This commit fixes a bug in the fetcher causing the news and link column to be populated with empty string instead of `null` value when the data is not available.
