### PR TITLE
Setup Debezium (Closes #41)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:16
+    image: quay.io/debezium/postgres:16
     container_name: postgres
     environment:
       POSTGRES_USER: postgres
@@ -20,20 +20,27 @@ services:
     ports:
       - "9092:9092"
       - "9094:9094"
+      - "9101:9101"
     volumes:
       - "kafka_data:/bitnami"
     environment:
+      ALLOW_PLAINTEXT_LISTENER: yes
       KAFKA_ENABLE_KRAFT: yes
+      KAFKA_BROKER_ID: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_CFG_JMX_PORT: 9101
+      KAFKA_CFG_HOST_NAME: kafka
       KAFKA_CFG_PROCESS_ROLES: broker,controller
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
       KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://kafka:9094
-      KAFKA_BROKER_ID: 1
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_CFG_NODE_ID: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
       KAFKA_CFG_NUM_PARTITIONS: 2
 
   kafka-ui:
@@ -60,6 +67,26 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+
+  connect:
+    image: quay.io/debezium/connect:2.7
+    container_name: debezium-connect
+    volumes:
+      - ./lib:/kafka/connect/kafka-connect-protobuf-converter-7.5.0
+    ports:
+      - "8083:8083"
+    depends_on:
+      - kafka
+      - postgres
+    links:
+      - kafka
+      - postgres
+    environment:
+      BOOTSTRAP_SERVERS: 'kafka:9092'
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: 'my_connect_configs'
+      OFFSET_STORAGE_TOPIC: 'my_connect_offsets'
+      STATUS_STORAGE_TOPIC: 'my_connect_statuses'
 
 volumes:
   postgres_data:

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -14,3 +14,19 @@ used by the fetcher are:
 The fetcher will fetch information from XKCD and stream it to the projection
 by using [Debezium](https://debezium.io) to capture changes in the database and
 stream them to the projection service.
+
+## Configuration
+
+To make the service run, the debezium connector must be created after running
+the command `docker-compose up` in the project root.
+
+To register the connector, use the [debezium-connector.http](debezium-connector.http)
+collection. This step could (and should) be automated in the future, but for now
+it is a good enough solution.
+
+## Debugging Kafka Messages
+
+To debug kafka messages, you can use the [kafka-ui](htttp://localhost:8080) that
+is running in the project.
+Use the `local` cluster to see the messages.
+The topic for the messages is `fetcher.xkcd_data_hub.web_comics_fetched.v1`.

--- a/fetcher/debezium-connector.http
+++ b/fetcher/debezium-connector.http
@@ -1,0 +1,51 @@
+### Create a new connector
+POST http://localhost:8083/connectors/
+Accept: application/json
+Content-Type: application/json
+
+{
+  "name": "data-platform-outbox-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "tasks.max": "1",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "secret",
+    "database.dbname" : "xkcd_data_hub",
+    "topic.prefix": "xkcd_data_hub",
+    "table.include.list": "public.outbox_event",
+    "transforms" : "outbox",
+    "transforms.outbox.type" : "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.route.topic.replacement" : "fetcher.xkcd_data_hub.${routedByValue}.v1"
+  }
+}
+
+### Create a new connector with SSL and authentication
+POST http://localhost:8083/connectors/
+Accept: application/json
+Content-Type: application/json
+
+{
+  "name": "data-platform-outbox-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "tasks.max": "1",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "secret",
+    "database.dbname" : "xkcd_data_hub",
+    "topic.prefix": "xkcd_data_hub",
+    "table.include.list": "public.outboxevent",
+    "transforms" : "outbox",
+    "transforms.outbox.type" : "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.route.topic.replacement" : "fetcher.xkcd_data_hub.${routedByValue}.v2",
+
+    "value.converter.schema.registry.ssl.truststore.location": "<location>",
+    "value.converter.schema.registry.ssl.truststore.password": "<truststore-password>",
+
+    "value.converter.basic.auth.credentials.source": "USER_INFO",
+    "value.converter.basic.auth.user.info": "{username}:{password}"
+  }
+}

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/WebComicPostgresAdapter.kt
@@ -1,12 +1,16 @@
 package com.xkcddatahub.fetcher.adapters.output.database.postgres
 
+import com.xkcddatahub.fetcher.adapters.output.database.postgres.data.DatabaseWebComics
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.mappers.DatabaseWebComicsMapper.toData
+import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.OutboxEventTable
 import com.xkcddatahub.fetcher.adapters.output.database.postgres.table.WebComicsTable
 import com.xkcddatahub.fetcher.application.ports.WebComicsPort
 import com.xkcddatahub.fetcher.bootstrap.DatabaseFactory.Companion.transaction
 import com.xkcddatahub.fetcher.domain.entity.WebComics
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.max
+import java.util.UUID
 
 class WebComicPostgresAdapter : WebComicsPort {
     override suspend fun save(comics: WebComics): Boolean =
@@ -24,8 +28,19 @@ class WebComicPostgresAdapter : WebComicsPort {
                 it[imageUrl] = data.imageUrl
                 it[news] = data.news
                 it[link] = data.link
-            }.insertedCount == 1
+            }
+                .takeIf { it.insertedCount == 1 }
+                ?.let { outbox(data) }
+                ?: false
         }
+
+    private fun outbox(comics: DatabaseWebComics): Boolean =
+        OutboxEventTable.insert {
+            it[id] = UUID.randomUUID()
+            it[aggregateType] = AGGREGATE_TYPE
+            it[aggregateId] = comics.id.toString()
+            it[payload] = comics
+        }.insertedCount == 1
 
     override suspend fun getLatestStoredComicId(): Int =
         transaction {
@@ -34,4 +49,8 @@ class WebComicPostgresAdapter : WebComicsPort {
                 .single()[WebComicsTable.id.max()]
                 ?: 0
         }
+
+    companion object {
+        private const val AGGREGATE_TYPE = "web_comics_fetched"
+    }
 }

--- a/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/table/OutboxEventTable.kt
+++ b/fetcher/src/main/kotlin/com/xkcddatahub/fetcher/adapters/output/database/postgres/table/OutboxEventTable.kt
@@ -1,0 +1,15 @@
+package com.xkcddatahub.fetcher.adapters.output.database.postgres.table
+
+import com.xkcddatahub.fetcher.adapters.output.database.postgres.data.DatabaseWebComics
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.json.jsonb
+
+object OutboxEventTable : Table("outbox_event") {
+    val id = uuid("id")
+    val aggregateType = varchar(name = "aggregatetype", length = 255)
+    val aggregateId = varchar(name = "aggregateid", length = 255)
+    val payload = jsonb<DatabaseWebComics>("payload", Json.Default)
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/fetcher/src/main/resources/db/migration/V1.1__create_outbox_table.sql
+++ b/fetcher/src/main/resources/db/migration/V1.1__create_outbox_table.sql
@@ -1,0 +1,7 @@
+create table outbox_event
+(
+    id            uuid primary key       not null,
+    aggregatetype character varying(255) not null,
+    aggregateid   character varying(255) not null,
+    payload       jsonb
+);

--- a/fetcher/src/main/resources/db/migration/V1.2__enable_uuid.sql
+++ b/fetcher/src/main/resources/db/migration/V1.2__enable_uuid.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ exposed_core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "e
 exposed_dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
 exposed_java_time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
 exposed_jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed_json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
 
 ## Persistence
 flyway = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
@@ -123,6 +124,7 @@ exposed_all = [
     "exposed_dao",
     "exposed_java_time",
     "exposed_jdbc",
+    "exposed_json",
 ]
 
 persistance_all = [


### PR DESCRIPTION
# Purpose

This commit creates a simple integration between the fetcher service and debezium allowing implementation of the outbox pattern for fetched comics.

The current setup requires manual creation of the connector using the http collection committed to the repo, but this should be automated in the future to be part of the docker compose startup process.


You can see an example of the generated events in the following image 🎉 

<img width="1438" alt="image" src="https://github.com/yonatankarp/xkcd-data-hub/assets/14914865/2f82194a-ecda-4597-ac6f-19b0e2648705">
