### PR TITLE
Build only submodule

### DIFF
--- a/.github/workflows/continues-integration.yml
+++ b/.github/workflows/continues-integration.yml
@@ -24,6 +24,7 @@ jobs:
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
     with:
       app_name: ${{ matrix.service }}
+      context: ${{ matrix.service }}
       build_dockerfile: true
 
   dependabot_auto_merge:


### PR DESCRIPTION


# Purpose

This commit ensures that each submodule in the project (AKA deployable unit / service) is built by itself, and not the entire project as a whole.

This will decrease build time as different components can be built in parallel, and components that have not changed will not be built at all.